### PR TITLE
Fix dbt-spark incompatibility for Databricks support (Close #37)

### DIFF
--- a/models/base/src_base.yml
+++ b/models/base/src_base.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: atomic
     schema: "{{ var('snowplow__atomic_schema', 'atomic') }}"
-    database: "{{ var('snowplow__database', target.database) if target.type not in ['databricks', 'spark'] else var('snowplow__atomic_schema', 'atomic') }}"
+    database: "{{ var('snowplow__database', target.database) if target.type not in ['databricks', 'spark'] else var('snowplow__databricks_catalog', 'hive_metastore') if target.type in ['databricks'] else var('snowplow__atomic_schema', 'atomic') }}"
     tables:
       - name: com_snowplowanalytics_snowplow_client_session_1
         description: '{{ doc("table_session_context") }}'


### PR DESCRIPTION
## Description & motivation
We need to make the Snowplow mobile model compatible with dbt Cloud for Databricks using the spark connector while still supporting the three-level-namespace that the dbt-databricks adapter enables.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
