### PR TITLE
Upgrade snowplow_utils package version (Close #43)

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_utils
-    version: [">=0.11.0", "<0.12.0"]
+    version: [">=0.11.0", "<0.13.0"]


### PR DESCRIPTION
## Description & motivation
We need to use the same version of snowplow_utils across all snowplow dbt packages to avoid version conflicts when installing multiple packages (e.g. web and mobile) in the same dbt project.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
