### PR TITLE
Move ref in enabled check (Close #61)

### DIFF
--- a/macros/stitch_user_identifiers.sql
+++ b/macros/stitch_user_identifiers.sql
@@ -1,20 +1,20 @@
-{% macro stitch_user_identifiers(enabled, relation=this, user_mapping_relation=ref('snowplow_mobile_user_mapping')) %}
+{% macro stitch_user_identifiers(enabled, relation=this, user_mapping_relation='snowplow_mobile_user_mapping') %}
 
   {% if enabled and target.type not in ['databricks', 'spark'] | as_bool() %}
 
     -- Update sessions table with mapping
     update {{ relation }} as s
     set stitched_user_id = um.user_id
-    from {{ user_mapping_relation }} as um
+    from {{ ref(user_mapping_relation) }} as um
     where s.device_user_id = um.device_user_id;
 
 {% elif enabled and target.type in ['databricks', 'spark']  | as_bool() %}
 
     -- Update sessions table with mapping
     merge into {{ relation }} as s
-    using {{ user_mapping_relation }} as um
+    using {{ ref(user_mapping_relation) }} as um
     on s.device_user_id = um.device_user_id
-    when matched then 
+    when matched then
       update set s.stitched_user_id = um.user_id;
 
   {% endif %}


### PR DESCRIPTION
## Description & motivation
Same changes as with web, this allows the user_mapping table to be disabled when user stitching is disabled.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

<!-- 
## Release Only Checklist
- [ ] I have updated the version number in all relevant places
- [ ] I have updated the CHANGELOG.md 
-->
