### PR TITLE
reduce previous_session_id test severity to warn (Close #62)

### DIFF
--- a/models/sessions/scratch/sessions_scratch.yml
+++ b/models/sessions/scratch/sessions_scratch.yml
@@ -19,7 +19,9 @@ models:
       - name: previous_session_id
         description: '{{ doc("col_previous_session_id") }}'
         tests:
-          - unique
+          - unique:
+              config:
+                severity: warn
       - name: session_first_event_id
         description: '{{ doc("col_session_first_event_id") }}'
         tests:

--- a/models/users/scratch/users_scratch.yml
+++ b/models/users/scratch/users_scratch.yml
@@ -189,7 +189,9 @@ models:
       - name: previous_session_id
         description: '{{ doc("col_previous_session_id") }}'
         tests:
-          - unique
+          - unique:
+              config:
+                severity: warn
       - name: session_first_event_id
         description: '{{ doc("col_session_first_event_id") }}'
         tests:


### PR DESCRIPTION
## Description & motivation
Reduce the severity of the unique test on `previous_session_id` to allow it to pass but still warn users of unexpected (but possible) behaviour.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

<!-- 
## Release Only Checklist
- [ ] I have updated the version number in all relevant places
- [ ] I have updated the CHANGELOG.md 
-->
