### PR TITLE
Add dedupe count to allow joining of multi-valued contexts

### DIFF
--- a/models/base/scratch/base_scratch.yml
+++ b/models/base/scratch/base_scratch.yml
@@ -251,7 +251,9 @@ models:
       - name: true_tstamp
         description: '{{ doc("col_true_tstamp") }}'
       - name: event_id_dedupe_index
-        description: ''
+        description: 'An indexing column used for de-duplication of raw events'
+      - name: event_id_dedupe_count
+        description: 'A count of the total duplicates of the event, used in Redshift/Postgres for joining entities in some cases'
       - name: row_count
         description: ''
       - name: event_index_in_session

--- a/models/base/scratch/redshift_postgres/snowplow_mobile_base_events_this_run.sql
+++ b/models/base/scratch/redshift_postgres/snowplow_mobile_base_events_this_run.sql
@@ -22,7 +22,8 @@ with events_this_run AS (
     sc.session_first_event_id,
 
     e.*,
-    row_number() over (partition by e.event_id order by e.collector_tstamp) as event_id_dedupe_index
+    row_number() over (partition by e.event_id order by e.collector_tstamp) as event_id_dedupe_index,
+    count(*) over (partition by e.event_id) as event_id_dedupe_count
 
   from {{ var('snowplow__events') }} e
   inner join {{ ref('snowplow_mobile_base_session_context') }} sc


### PR DESCRIPTION
## Description & motivation
Aligns mobile de-dupe to the same as the web, allowing for joining contexts with valid duplicate values.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)