### PR TITLE
Release/snowplow mobile/0.7.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+snowplow-mobile 0.7.1 (2023-06-28)
+---------------------------------------
+## Summary
+
+This release allows users to join contexts with valid duplicate values with the help of a new field called `event_id_dedupe_count`, just like in the web model. It also reenables integration tests for Redshift and refactors code for increased readability and simplicity.
+
+## Features
+- Add dedupe count to allow joining of multi-valued contexts
+- Integration tests do not run on Redshift (Close #70)
+- Modify source definition to handle integration tests
+
+## Upgrading
+Bump the snowplow-mobile version in your `packages.yml` file, and ensuring you have followed the above steps. You can read more in our [upgrade guide](https://docs.snowplow.io/docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/mobile/#upgrading-to-0140)
+
 snowplow-mobile 0.7.0 (2023-03-28)
 ---------------------------------------
 ## Summary
@@ -5,7 +19,7 @@ This version contains two major changes, the first is to migrates our models awa
 
 ## 🚨 Breaking Changes 🚨
 ### Changes to materialization
-To take advantage of the optimization we apply to the `incremental` materialization, users will need to add the following to their `dbt_project.yml` : 
+To take advantage of the optimization we apply to the `incremental` materialization, users will need to add the following to their `dbt_project.yml` :
 ```yaml
 # dbt_project.yml
 ...
@@ -41,7 +55,7 @@ Move ref in enabled check (Close #61)
 Reduce previous_session_id test severity to warn (Close #62)
 
 ## Upgrading
-To upgrade simply bump the snowplow-web version in your `packages.yml` file.  
+To upgrade simply bump the snowplow-web version in your `packages.yml` file.
 
 snowplow-mobile 0.6.2 (2023-01-23)
 ---------------------------------------
@@ -54,7 +68,7 @@ Add action for generating docs for pages
 Fix databricks geolocation aliasing (Close #57)
 
 ## Upgrading
-To upgrade simply bump the snowplow-web version in your `packages.yml` file.  
+To upgrade simply bump the snowplow-web version in your `packages.yml` file.
 
 snowplow-mobile 0.6.1 (2022-12-13)
 ---------------------------------------
@@ -65,7 +79,7 @@ This release alters the Databricks `snowplow_mobile_base_events_this_run` table 
 Add all columns to `snowplow_mobile_base_events_this_run` for databricks.
 
 ## Upgrading
-To upgrade simply bump the snowplow-web version in your `packages.yml` file.  
+To upgrade simply bump the snowplow-web version in your `packages.yml` file.
 Any custom models built directly off `snowplow_mobile_base_events_this_run` in databricks may need altering if you `select *` from this table.
 
 snowplow-mobile 0.6.0 (2022-12-08)

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_mobile'
-version: '0.7.0'
+version: '0.7.1'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/.scripts/integration_test.sh
+++ b/integration_tests/.scripts/integration_test.sh
@@ -25,11 +25,11 @@ for db in ${DATABASES[@]}; do
 
   echo "Snowplow mobile integration tests: Seeding data"
 
-  eval "dbt seed --target $db --full-refresh" || exit 1;
+  eval "dbt seed --full-refresh --target $db" || exit 1;
 
   echo "Snowplow mobile integration tests: Execute models - run 1/4"
 
-  eval "dbt run --target $db --full-refresh --vars '{snowplow__allow_refresh: true, snowplow__backfill_limit_days: 60}'" || exit 1;
+  eval "dbt run --full-refresh --vars '{snowplow__allow_refresh: true, snowplow__backfill_limit_days: 60}' --target $db" || exit 1;
 
   for i in {2..4}
   do

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -192,9 +192,9 @@ seeds:
           event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
           event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
           true_tstamp: timestamp
-          contexts_com_snowplowanalytics_snowplow_client_session_1_0_1: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-          unstruct_event_com_snowplowanalytics_mobile_screen_view_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-          contexts_com_snowplowanalytics_snowplow_geolocation_context_1_1_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+          contexts_com_snowplowanalytics_snowplow_client_session_1_0_1: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar(65535)' }}"
+          unstruct_event_com_snowplowanalytics_mobile_screen_view_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar(65535)' }}"
+          contexts_com_snowplowanalytics_snowplow_geolocation_context_1_1_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar(65535)' }}"
     expected:
       bigquery:
         +enabled: "{{ target.type == 'bigquery' | as_bool() }}"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_mobile_integration_tests'
-version: '0.7.0'
+version: '0.7.1'
 config-version: 2
 
 profile: 'integration_tests'

--- a/integration_tests/models/source/default/snowplow_mobile_geolocation_context_stg.sql
+++ b/integration_tests/models/source/default/snowplow_mobile_geolocation_context_stg.sql
@@ -48,13 +48,13 @@ with prep as (
 select
     root_id,
     root_tstamp,
-    case when latitude = 'null' then null else latitude::numeric end as latitude,
-    case when longitude = 'null' then null else longitude::numeric end as longitude,
-    case when latitude_longitude_accuracy = 'null' then null else latitude_longitude_accuracy::numeric end as latitude_longitude_accuracy,
-    case when altitude = 'null' then null else altitude::numeric end as altitude,
-    case when altitude_accuracy = 'null' then null else altitude_accuracy::numeric end as altitude_accuracy,
-    case when bearing = 'null' then null else bearing::numeric end as bearing,
-    case when speed = 'null' then null else speed::numeric end as speed,
+    case when latitude = 'null' then null else latitude::float end as latitude,
+    case when longitude = 'null' then null else longitude::float end as longitude,
+    case when latitude_longitude_accuracy = 'null' then null else latitude_longitude_accuracy::float end as latitude_longitude_accuracy,
+    case when altitude = 'null' then null else altitude::float end as altitude,
+    case when altitude_accuracy = 'null' then null else altitude_accuracy::float end as altitude_accuracy,
+    case when bearing = 'null' then null else bearing::float end as bearing,
+    case when speed = 'null' then null else speed::float end as speed,
     case when timestamp = 'null' then null else timestamp::INTEGER end as timestamp
 
 from prep

--- a/macros/get_path_sql.sql
+++ b/macros/get_path_sql.sql
@@ -15,16 +15,9 @@
 
 {% macro bigquery__get_session_id_path_sql(relation_alias) %}
 
--- setting relation through variable is not currently supported (recognised as string), different logic for integration tests
-{% if target.schema.startswith('gh_sp_mobile_dbt_') %}
-
-  {%- set relation=ref('snowplow_mobile_events_stg') %}
-
-{% else %}
+-- setting relation through variable is not currently supported (recognised as string)
 
   {%- set relation=source('atomic','events') %}
-
-{% endif %}
 
   {%- set session_id = snowplow_utils.combine_column_versions(
                                   relation=relation,

--- a/models/base/scratch/base_scratch.yml
+++ b/models/base/scratch/base_scratch.yml
@@ -251,7 +251,9 @@ models:
       - name: true_tstamp
         description: '{{ doc("col_true_tstamp") }}'
       - name: event_id_dedupe_index
-        description: ''
+        description: 'An indexing column used for de-duplication of raw events'
+      - name: event_id_dedupe_count
+        description: 'A count of the total duplicates of the event, used in Redshift/Postgres for joining entities in some cases'
       - name: row_count
         description: ''
       - name: event_index_in_session

--- a/models/base/scratch/bigquery/snowplow_mobile_base_events_this_run.sql
+++ b/models/base/scratch/bigquery/snowplow_mobile_base_events_this_run.sql
@@ -13,52 +13,6 @@
 with events as (
   select
 
--- handling relations for integration tests
-  {% if target.schema.startswith('gh_sp_mobile_dbt_') %}
-    -- screen view events
-    {{ snowplow_utils.get_optional_fields(
-          enabled=true,
-          col_prefix='unstruct_event_com_snowplowanalytics_mobile_screen_view_1_',
-          fields=screen_view_event_fields(),
-          relation=ref('snowplow_mobile_events_stg'),
-          relation_alias='a') }},
-    -- session context
-    {{ snowplow_utils.get_optional_fields(
-          enabled=true,
-          col_prefix='contexts_com_snowplowanalytics_snowplow_client_session_1_',
-          fields=session_context_fields(),
-          relation=ref('snowplow_mobile_events_stg'),
-          relation_alias='a') }},
-    -- screen context
-    {{ snowplow_utils.get_optional_fields(
-          enabled=var('snowplow__enable_screen_context', false),
-          col_prefix='contexts_com_snowplowanalytics_mobile_screen_1_',
-          fields=screen_context_fields(),
-          relation=ref('snowplow_mobile_events_stg'),
-          relation_alias='a') }},
-    -- mobile context
-    {{ snowplow_utils.get_optional_fields(
-          enabled=var('snowplow__enable_mobile_context', false),
-          col_prefix='contexts_com_snowplowanalytics_snowplow_mobile_context_1_',
-          fields=mobile_context_fields(),
-          relation=ref('snowplow_mobile_events_stg'),
-          relation_alias='a') }},
-    -- geo context
-    {{ snowplow_utils.get_optional_fields(
-          enabled=var('snowplow__enable_geolocation_context', false),
-          col_prefix='contexts_com_snowplowanalytics_snowplow_geolocation_context_1_',
-          fields=geo_context_fields(),
-          relation=ref('snowplow_mobile_events_stg'),
-          relation_alias='a') }},
-    -- app context
-    {{ snowplow_utils.get_optional_fields(
-          enabled=var('snowplow__enable_application_context', false),
-          col_prefix='contexts_com_snowplowanalytics_mobile_application_1_',
-          fields=app_context_fields(),
-          relation=ref('snowplow_mobile_events_stg'),
-          relation_alias='a') }},
-
-  {% else %}
     -- screen view events
     {{ snowplow_utils.get_optional_fields(
           enabled=true,
@@ -101,8 +55,6 @@ with events as (
           fields=session_context_fields(),
           relation=source('atomic','events'),
           relation_alias='a') }},
-
-    {% endif %}
 
     a.*
 

--- a/models/base/scratch/redshift_postgres/snowplow_mobile_base_events_this_run.sql
+++ b/models/base/scratch/redshift_postgres/snowplow_mobile_base_events_this_run.sql
@@ -22,7 +22,8 @@ with events_this_run AS (
     sc.session_first_event_id,
 
     e.*,
-    row_number() over (partition by e.event_id order by e.collector_tstamp) as event_id_dedupe_index
+    row_number() over (partition by e.event_id order by e.collector_tstamp) as event_id_dedupe_index,
+    count(*) over (partition by e.event_id) as event_id_dedupe_count
 
   from {{ var('snowplow__events') }} e
   inner join {{ ref('snowplow_mobile_base_session_context') }} sc

--- a/models/base/src_base.yml
+++ b/models/base/src_base.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: atomic
-    schema: "{{ var('snowplow__atomic_schema', 'atomic') }}"
+    schema: "{{ var('snowplow__atomic_schema', 'atomic') if project_name != 'snowplow_mobile_integration_tests' else target.schema~'_snplw_mobile_int_tests' }}"
     database: "{{ var('snowplow__database', target.database) if target.type not in ['databricks', 'spark'] else var('snowplow__databricks_catalog', 'hive_metastore') if target.type in ['databricks'] else var('snowplow__atomic_schema', 'atomic') }}"
     tables:
       - name: com_snowplowanalytics_snowplow_client_session_1
@@ -153,8 +153,8 @@ sources:
           - name: type
             description: '{{ doc("col_screen_view_type") }}'
       - name: events
+        identifier: "{{ var('snowplow__events_table', 'events') if project_name != 'snowplow_mobile_integration_tests' else 'snowplow_mobile_events_stg' }}"
         description: '{{ doc("table_events") }}'
-        identifier: "{{ var('snowplow__events_table', 'events') }}"
         columns:
           - name: app_id
             description: '{{ doc("col_app_id") }}'


### PR DESCRIPTION
## Description & motivation
This release allows users to join contexts with valid duplicate values with the help of a new field called `event_id_dedupe_count`, just like in the web model. It also reenables integration tests for Redshift and refactors code for increased readability and simplicity.


## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation/pull/507) PR if applicable (Link here if required)

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 

